### PR TITLE
fix: stops recursion if unsat

### DIFF
--- a/src/solver.js
+++ b/src/solver.js
@@ -43,6 +43,8 @@ export class Solver{
                 let result = this.backtrack();
                 if(result){
                     return true;
+                } else {
+                  return false;
                 }
             }           
         }


### PR DESCRIPTION
I observed endless recursion if constraints given were unsat. This change will make the function report to the user quickly that the problem given is unsat.